### PR TITLE
[BB2-1210] Fix SDK GetAccessToken Axios Post 400 Err

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,7 @@
   },
   "dependencies": {
     "@microsoft/api-extractor": "^7.19.4",
-    "@types/form-data": "^2.5.0",
     "axios": "^0.26.1",
-    "form-data": "^4.0.0",
     "moment": "^2.29.1",
     "typedoc": "^0.22.11"
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
   },
   "dependencies": {
     "@microsoft/api-extractor": "^7.19.4",
+    "@types/form-data": "^2.5.0",
     "axios": "^0.26.1",
+    "form-data": "^4.0.0",
     "moment": "^2.29.1",
     "typedoc": "^0.22.11"
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,6 +3,7 @@
  */
 import axios from "axios";
 import crypto from "crypto";
+import FormData from "form-data";
 
 import BlueButton from ".";
 import { AuthorizationToken } from "./entities/AuthorizationToken";
@@ -143,9 +144,27 @@ export async function getAuthorizationToken(
 
   const postData = generateTokenPostData(bb, authData, callbackRequestCode);
 
-  const resp = await axios.post(getAccessTokenUrl(bb), postData, {
-    headers: { [SDK_HEADER_KEY]: SDK_HEADER },
-  });
+  const form = new FormData();
+
+  form.append("client_id", postData.client_id);
+  form.append("client_secret", postData.client_secret);
+  form.append("code", postData.code);
+  form.append("grant_type", "authorization_code");
+  form.append("redirect_uri", postData.redirect_uri);
+  form.append("code_verifier", postData.code_verifier);
+  form.append("code_challenge", postData.code_challenge);
+
+  const url = getAccessTokenUrl(bb);
+  const headers = { [SDK_HEADER_KEY]: SDK_HEADER, ...form.getHeaders() };
+  const resp = await axios.post(url, form, { headers: headers });
+  // form.getHearders() will generate Content type header with boundary as below example:
+  // "multipart/form-data; boundary=--------------------------871743645947203066115383"
+  // and the form is delimited with the boundary
+
+  // original sdk code:
+  // const resp = await axios.post(getAccessTokenUrl(bb), postData, {
+  //   headers: { [SDK_HEADER_KEY]: SDK_HEADER },
+  // });
 
   if (resp.data) {
     const authToken = new AuthorizationToken(resp.data);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,6 @@
  */
 import axios from "axios";
 import crypto from "crypto";
-import FormData from "form-data";
 
 import BlueButton from ".";
 import { AuthorizationToken } from "./entities/AuthorizationToken";
@@ -144,27 +143,10 @@ export async function getAuthorizationToken(
 
   const postData = generateTokenPostData(bb, authData, callbackRequestCode);
 
-  const form = new FormData();
-
-  form.append("client_id", postData.client_id);
-  form.append("client_secret", postData.client_secret);
-  form.append("code", postData.code);
-  form.append("grant_type", "authorization_code");
-  form.append("redirect_uri", postData.redirect_uri);
-  form.append("code_verifier", postData.code_verifier);
-  form.append("code_challenge", postData.code_challenge);
-
-  const url = getAccessTokenUrl(bb);
-  const headers = { [SDK_HEADER_KEY]: SDK_HEADER, ...form.getHeaders() };
-  const resp = await axios.post(url, form, { headers: headers });
-  // form.getHearders() will generate Content type header with boundary as below example:
-  // "multipart/form-data; boundary=--------------------------871743645947203066115383"
-  // and the form is delimited with the boundary
-
-  // original sdk code:
-  // const resp = await axios.post(getAccessTokenUrl(bb), postData, {
-  //   headers: { [SDK_HEADER_KEY]: SDK_HEADER },
-  // });
+  const body = new URLSearchParams(postData);
+  const resp = await axios.post(getAccessTokenUrl(bb), body, {
+    headers: { [SDK_HEADER_KEY]: SDK_HEADER },
+  });
 
   if (resp.data) {
     const authToken = new AuthorizationToken(resp.data);


### PR DESCRIPTION
Jira Ticket:

[BB2-1210](https://jira.cms.gov/browse/BB2-1210)

*Context:*

When trying out Node SDK in a sample app, get 400 (Bad Request: unsupported grant type) from get access token POST operation.

*Root cause analysis:*

{code:java}
  const postData = generateTokenPostData(bb, authData, callbackRequestCode);

  const resp = await axios.post(getAccessTokenUrl(bb), postData, {
    headers: { [SDK_HEADER_KEY]: SDK_HEADER },
  });
{code}

The root cause is that the headers passed into axios.post(url, data, {headers: { [SDK_HEADER_KEY]: SDK_HEADER },}) , is not properly generated for post form data, below code (tested and worked) will properly generate the proper headers (Content-type) for post form data - see above code snippet.

AC:

The bug fixed and SDK getAccessToken works as expected.

To Reproduce the bug and verify the fix:

Use the PR review helper PR where a docker compose is available to do end to end with webUI:

https://github.com/CMSgov/cms-bb2-node-sdk/pull/10

to verify the fix, toggle the commented out code in src/auth.ts (line 130 - 175)

